### PR TITLE
Make the gem compatible with ActiveSupport 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,21 @@ PATH
   remote: .
   specs:
     redash_exporter (0.3.0)
-      activesupport (~> 5.2.3)
+      activesupport (>= 5.2.3)
       zaru (~> 0.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (6.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     ast (2.4.0)
     byebug (11.0.1)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     coveralls (0.8.22)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -24,11 +25,11 @@ GEM
       tins (~> 1.6)
     diff-lcs (1.3)
     docile (1.3.1)
-    i18n (1.6.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
     json (2.2.0)
-    minitest (5.11.3)
+    minitest (5.14.0)
     parallel (1.17.0)
     parser (2.6.2.1)
       ast (~> 2.4.0)
@@ -67,10 +68,11 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tins (1.20.2)
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.5.0)
     zaru (0.1.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby

--- a/redash_exporter.gemspec
+++ b/redash_exporter.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 5.2.3"
+  spec.add_dependency "activesupport", ">= 5.2.3"
   spec.add_dependency "zaru", "~> 0.1.0"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
I've briefly tested it with Active Support 6 with Rails 6 application and it seems to be working without any issues. Any objection to relax versioning for `activesupport`?